### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ plotly==5.14.1
 python-Levenshtein==0.20.9
 Levenshtein==0.20.9
 pandas==1.5.3
+numpy==1.26.4


### PR DESCRIPTION
Specifying Numpy version, otherwise it upgrades to Numpy2 and return a "ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject" when we try to run the app